### PR TITLE
feat(team): editable member names/phones; extend profiles RLS for ten…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ CRON_SECRET=
 
 # Optional for local seeds
 SEED_TENANT_ID=
+SEED_CT_METER_KW=8
+SEED_CABLE_M_PER_KW=10
 
 # PDF Malayalam font embedding (optional)
 # Either set a full URL to a TTF (e.g., https://your-domain/fonts/NotoSansMalayalam-Regular.ttf)

--- a/app/api/team/member/route.ts
+++ b/app/api/team/member/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { supabaseFromAuthHeader } from '@/lib/supabaseServer';
+
+const BodySchema = z.object({
+  userId: z.string().uuid(),
+  displayName: z.string().min(1).max(120).optional(),
+  phone: z.string().min(0).max(32).optional(),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const sb = supabaseFromAuthHeader(req.headers.get('authorization'));
+    if (!sb)
+      return NextResponse.json(
+        { ok: false, error: 'Unauthorized' },
+        { status: 401 },
+      );
+    const parsed = BodySchema.safeParse(await req.json());
+    if (!parsed.success)
+      return NextResponse.json(
+        { ok: false, error: 'Invalid payload' },
+        { status: 400 },
+      );
+    const { userId, displayName, phone } = parsed.data;
+    const { data: me } = await sb
+      .from('profiles')
+      .select('tenant_id, role')
+      .maybeSingle();
+    if (!me?.tenant_id)
+      return NextResponse.json(
+        { ok: false, error: 'Profile not ready' },
+        { status: 400 },
+      );
+    if (!['owner', 'admin'].includes((me as any).role))
+      return NextResponse.json(
+        { ok: false, error: 'Forbidden' },
+        { status: 403 },
+      );
+
+    const patch: any = {};
+    if (displayName !== undefined) patch.display_name = displayName;
+    if (phone !== undefined) patch.phone = phone || null;
+    if (Object.keys(patch).length === 0)
+      return NextResponse.json({ ok: true });
+
+    const { error } = await sb
+      .from('profiles')
+      .update(patch)
+      .eq('user_id', userId)
+      .eq('tenant_id', (me as any).tenant_id);
+    if (error)
+      return NextResponse.json(
+        { ok: false, error: 'Update failed' },
+        { status: 500 },
+      );
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    const id = Math.random().toString(36).slice(2, 10);
+    console.error('api/team/member', { id, error: e });
+    return NextResponse.json(
+      { ok: false, error: 'Internal error', id },
+      { status: 500 },
+    );
+  }
+}
+

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -135,10 +135,60 @@ export default function JobsPage() {
         .from('profiles')
         .select('tenant_id')
         .maybeSingle();
+      const tenantId = (prof as any)!.tenant_id as string;
+
+      // Ensure a corresponding lead exists to avoid pipeline/leads mismatch
+      let leadId: string | null = null;
+      try {
+        // Fetch customer details for lead creation
+        const { data: cust } = await supabase
+          .from('customers')
+          .select('name, phone, address')
+          .eq('id', custId)
+          .maybeSingle();
+        // Try reuse: find the most recent lead by phone in the same tenant
+        if (cust?.phone) {
+          const { data: existing } = await supabase
+            .from('leads')
+            .select('id, status')
+            .eq('tenant_id', tenantId)
+            .eq('phone', cust.phone)
+            .order('date', { ascending: false })
+            .limit(1);
+          const reuse = Array.isArray(existing) ? existing[0] : null;
+          if (reuse?.id) {
+            leadId = reuse.id as string;
+            // If not converted, mark as converted since we're creating a job now
+            if (reuse.status !== 'Converted') {
+              await supabase.from('leads').update({ status: 'Converted' }).eq('id', leadId);
+            }
+          }
+        }
+        if (!leadId) {
+          const today = new Date().toISOString().slice(0, 10);
+          const { data: lead } = await supabase
+            .from('leads')
+            .insert({
+              tenant_id: tenantId,
+              date: today,
+              name: selectedCustomer?.name || cust?.name || 'Lead',
+              phone: (cust as any)?.phone || null,
+              address: location || (cust as any)?.address || null,
+              interested_capacity_kw: capacity,
+              status: 'Converted',
+              branch_id: branchId !== 'all' ? (branchId as string) : null,
+              source: 'Job',
+            })
+            .select('id')
+            .single();
+          leadId = (lead as any)?.id || null;
+        }
+      } catch {}
+
       const { data: job } = await supabase
         .from('jobs')
         .insert({
-          tenant_id: (prof as any)!.tenant_id,
+          tenant_id: tenantId,
           customer_id: custId,
           system_type: systemType,
           program_type: program,
@@ -148,6 +198,7 @@ export default function JobsPage() {
           roof_type: roof || null,
           date_lead: new Date().toISOString().slice(0, 10),
           branch_id: branchId !== 'all' ? branchId : null,
+          lead_id: leadId,
         })
         .select('id')
         .single();

--- a/app/leads/page.tsx
+++ b/app/leads/page.tsx
@@ -12,6 +12,7 @@ import { PROGRAM_ALLOWED_SYSTEMS, type ProgramType } from '@/lib/program';
 import BranchSelect from '~/components/BranchSelect';
 import RequireOwner from '~/components/RequireOwner';
 import { useConfirm } from '~/components/ui/ConfirmProvider';
+import Segmented from '~/components/ui/Segmented';
 
 export default function LeadsPage() {
   const supabase = supabaseBrowser();
@@ -44,11 +45,17 @@ export default function LeadsPage() {
   const [branchNames, setBranchNames] = useState<Record<string, string>>({});
   const [kpis, setKpis] = useState<any | null>(null);
   const [kpiLoading, setKpiLoading] = useState(false);
+  const [jobsLeadCount, setJobsLeadCount] = useState<number | null>(null);
   const [importing, setImporting] = useState(false);
   const [importResult, setImportResult] = useState<any | null>(null);
   const [dedupeMode, setDedupeMode] = useState<'create' | 'skip' | 'update'>(
     'create',
   );
+  // Filters
+  const [filterMode, setFilterMode] = useState<'open' | 'all' | 'converted'>(
+    'open',
+  );
+  const [dueOnly, setDueOnly] = useState(false);
   // Branches for add/edit choices
   const [branches, setBranches] = useState<any[]>([]);
   // Per-add override: use selected branch, specific branch, or unassigned
@@ -84,6 +91,7 @@ export default function LeadsPage() {
         const token = session.session?.access_token;
         if (!token) {
           setKpis(null);
+          setJobsLeadCount(null);
           setKpiLoading(false);
           return;
         }
@@ -97,8 +105,21 @@ export default function LeadsPage() {
         const out = await res.json();
         if (res.ok && out?.ok) setKpis(out);
         else setKpis(null);
+        // Also compute Jobs in Lead stage (pipeline) count for clarity
+        try {
+          let jq = supabase
+            .from('jobs')
+            .select('id', { count: 'exact', head: true })
+            .eq('status', 'Lead');
+          if (branchId !== 'all') jq = jq.eq('branch_id', branchId as string);
+          const { count } = await jq;
+          setJobsLeadCount(count || 0);
+        } catch {
+          setJobsLeadCount(null);
+        }
       } catch {
         setKpis(null);
+        setJobsLeadCount(null);
       } finally {
         setKpiLoading(false);
       }
@@ -142,6 +163,13 @@ export default function LeadsPage() {
       .select('*')
       .order('date', { ascending: false });
     if (branchId !== 'all') q = q.eq('branch_id', branchId as string);
+    if (filterMode === 'open')
+      q = q
+        .neq('status', 'Converted')
+        .neq('status', 'Closed')
+        .neq('status', 'Lost');
+    else if (filterMode === 'converted') q = q.eq('status', 'Converted');
+    if (dueOnly) q = q.eq('next_follow_up_date', todayStr);
     const { data, error } = await q;
     if (error) {
       // Surface server-side error details and show a friendly UI error
@@ -163,7 +191,56 @@ export default function LeadsPage() {
       setLoadingList(false);
       return;
     }
-    setLeads(data || []);
+    let rows: any[] = (data as any[]) || [];
+
+    // Merge job-only Lead-stage cards as read-only rows (unless Due-only or Converted filter)
+    if (!dueOnly && filterMode !== 'converted') {
+      try {
+        let jq = supabase
+          .from('jobs')
+          .select('id, customer_id, branch_id, date_lead, created_at, status, lead_id')
+          .eq('status', 'Lead')
+          .is('lead_id', null)
+          .order('created_at', { ascending: false });
+        if (branchId !== 'all') jq = jq.eq('branch_id', branchId as string);
+        const { data: jrows } = await jq;
+        const jobs = ((jrows as any[]) || []) as any[];
+        if (jobs.length > 0) {
+          const ids = Array.from(new Set(jobs.map((r) => r.customer_id).filter(Boolean)));
+          let cmap = new Map<string, any>();
+          if (ids.length > 0) {
+            const { data: custs } = await supabase
+              .from('customers')
+              .select('id, name, phone, address')
+              .in('id', ids as any);
+            for (const c of ((custs as any[]) || []) as any[]) cmap.set(c.id, c);
+          }
+          const jobLeads = jobs.map((j) => {
+            const c = cmap.get(j.customer_id) || {};
+            const date = j.date_lead || j.created_at?.slice(0, 10) || todayStr;
+            return {
+              id: `job-${j.id}`,
+              date,
+              name: c.name || '—',
+              phone: c.phone || '',
+              address: c.address || '',
+              source: 'Job',
+              interested_capacity_kw: null,
+              next_follow_up_date: null,
+              last_contacted_at: null,
+              status: 'Lead (job)',
+              branch_id: j.branch_id || null,
+              notes: '',
+              _jobOnly: true,
+              _jobId: j.id,
+            } as any;
+          });
+          rows = [...jobLeads, ...rows];
+        }
+      } catch {}
+    }
+
+    setLeads(rows);
     setLoadingList(false);
   };
 
@@ -172,7 +249,7 @@ export default function LeadsPage() {
     supabase.auth.getSession().then(({ data }) => {
       if (data.session) load();
     });
-  }, [branchId]);
+  }, [branchId, filterMode, dueOnly]);
 
   const add = async () => {
     setErr(null);
@@ -248,6 +325,26 @@ export default function LeadsPage() {
         <div className="min-w-[220px]">
           <BranchSelect value={branchId} onChange={setBranchId} />
         </div>
+      </div>
+      {/* Simple filters: default to Open, optional Due today */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Segmented
+          options={[
+            { label: 'Open', value: 'open' },
+            { label: 'All', value: 'all' },
+            { label: 'Converted', value: 'converted' },
+          ]}
+          value={filterMode}
+          onChange={(v) => setFilterMode(v as any)}
+        />
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={dueOnly}
+            onChange={(e) => setDueOnly(e.target.checked)}
+          />
+          Due today
+        </label>
       </div>
       {/* Quick add: single field capture */}
       <Card>
@@ -417,6 +514,13 @@ export default function LeadsPage() {
             </div>
           </div>
         ))}
+      {/* Clarification: Jobs pipeline Lead-stage count can differ from Leads */}
+      {!kpiLoading && jobsLeadCount != null && (
+        <div className="rounded border bg-white p-3 text-center">
+          <div className="text-xs text-gray-500">Jobs in Lead Stage</div>
+          <div className="text-lg font-semibold">{jobsLeadCount}</div>
+        </div>
+      )}
       {err && (
         <div className="rounded border bg-red-50 p-2 text-sm text-red-700">
           {err}
@@ -727,7 +831,9 @@ export default function LeadsPage() {
                       onChange={(e) => {
                         const v = e.target.checked;
                         const map: Record<string, boolean> = {};
-                        (leads || []).forEach((l) => (map[l.id] = v));
+                        (leads || []).forEach((l) => {
+                          if (!(l as any)._jobOnly) map[l.id] = v;
+                        });
                         setSelected(map);
                       }}
                     />
@@ -751,16 +857,20 @@ export default function LeadsPage() {
                   <React.Fragment key={l.id}>
                     <tr className="border-b">
                       <td className="p-2">
-                        <input
-                          type="checkbox"
-                          checked={!!selected[l.id]}
-                          onChange={(e) =>
-                            setSelected({
-                              ...selected,
-                              [l.id]: e.target.checked,
-                            })
-                          }
-                        />
+                        {(l as any)._jobOnly ? (
+                          <input type="checkbox" disabled title="Job card (read-only)" />
+                        ) : (
+                          <input
+                            type="checkbox"
+                            checked={!!selected[l.id]}
+                            onChange={(e) =>
+                              setSelected({
+                                ...selected,
+                                [l.id]: e.target.checked,
+                              })
+                            }
+                          />
+                        )}
                       </td>
                       <td className="p-2">{l.date || '—'}</td>
                       {editing === l.id ? (
@@ -987,43 +1097,99 @@ export default function LeadsPage() {
                             <span title={l.notes || ''}>{l.notes || '—'}</span>
                           </td>
                           <td className="p-2 whitespace-nowrap">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => {
-                                setEditing(l.id);
-                                setEditForm(l);
-                              }}
-                            >
-                              Edit
-                            </Button>
-                            <RequireOwner>
+                            {(l as any)._jobOnly ? (
+                              <>
+                                <Button
+                                  size="sm"
+                                  onClick={async () => {
+                                    // Create a corresponding lead and link this job
+                                    const { data: prof } = await supabase
+                                      .from('profiles')
+                                      .select('tenant_id')
+                                      .maybeSingle();
+                                    const tenantId = (prof as any)?.tenant_id as string;
+                                    const today = new Date().toISOString().slice(0, 10);
+                                    const { data: lead } = await supabase
+                                      .from('leads')
+                                      .insert({
+                                        tenant_id: tenantId,
+                                        date: (l as any).date || today,
+                                        name: (l as any).name || 'Lead',
+                                        phone: (l as any).phone || null,
+                                        address: (l as any).address || null,
+                                        interested_capacity_kw: (l as any).interested_capacity_kw || null,
+                                        status: 'Converted',
+                                        source: 'Job',
+                                        branch_id:
+                                          (l as any).branch_id ||
+                                          (branchId !== 'all' ? (branchId as string) : null),
+                                      })
+                                      .select('id')
+                                      .single();
+                                    const newLeadId = (lead as any)?.id as string;
+                                    if (newLeadId && (l as any)._jobId) {
+                                      await supabase
+                                        .from('jobs')
+                                        .update({ lead_id: newLeadId })
+                                        .eq('id', (l as any)._jobId);
+                                      toast({ title: 'Linked job to lead', variant: 'success' });
+                                      load();
+                                    }
+                                  }}
+                                >
+                                  Link Lead
+                                </Button>
+                                <a
+                                  href={`/jobs/${(l as any)._jobId}`}
+                                  className="ml-2 rounded border px-2 py-1 text-sm"
+                                >
+                                  Open Job
+                                </a>
+                              </>
+                            ) : (
+                              <>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => {
+                                    setEditing(l.id);
+                                    setEditForm(l);
+                                  }}
+                                >
+                                  Edit
+                                </Button>
+                              </>
+                            )}
+                            {!((l as any)._jobOnly) && (
+                              <RequireOwner>
+                                <Button
+                                  variant="danger"
+                                  size="sm"
+                                  className="ml-2"
+                                  onClick={async () => {
+                                    const ok = await confirm({
+                                      title: 'Delete lead',
+                                      description:
+                                        'Are you sure you want to permanently delete this lead?',
+                                      confirmText: 'Delete',
+                                    });
+                                    if (!ok) return;
+                                    await supabase
+                                      .from('leads')
+                                      .delete()
+                                      .eq('id', l.id);
+                                    load();
+                                  }}
+                                >
+                                  Delete
+                                </Button>
+                              </RequireOwner>
+                            )}
+                            {!((l as any)._jobOnly) && (
                               <Button
-                                variant="danger"
                                 size="sm"
                                 className="ml-2"
-                                onClick={async () => {
-                                  const ok = await confirm({
-                                    title: 'Delete lead',
-                                    description:
-                                      'Are you sure you want to permanently delete this lead?',
-                                    confirmText: 'Delete',
-                                  });
-                                  if (!ok) return;
-                                  await supabase
-                                    .from('leads')
-                                    .delete()
-                                    .eq('id', l.id);
-                                  load();
-                                }}
-                              >
-                                Delete
-                              </Button>
-                            </RequireOwner>
-                            <Button
-                              size="sm"
-                              className="ml-2"
-                              onClick={() => {
+                                onClick={() => {
                                 // confirmation dialog
                                 confirm({
                                   title: 'Convert lead',
@@ -1041,10 +1207,11 @@ export default function LeadsPage() {
                                     roof_type: '',
                                   });
                                 });
-                              }}
-                            >
-                              Convert
-                            </Button>
+                                }}
+                              >
+                                Convert
+                              </Button>
+                            )}
                             {/* Removed 'Followed up' button to reduce clutter */}
                             {l.phone && (
                               <a

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -507,7 +507,8 @@ export default function SettingsPage() {
               <table className="w-full text-sm">
                 <thead>
                   <tr className="text-left text-gray-600">
-                    <th className="p-2">User</th>
+                    <th className="p-2">Name</th>
+                    <th className="p-2">Phone</th>
                     <th className="p-2">User ID</th>
                     <th className="p-2">Role</th>
                   </tr>
@@ -515,11 +516,106 @@ export default function SettingsPage() {
                 <tbody>
                   {team.map((m) => (
                     <tr key={m.user_id} className="border-t">
-                      <td
-                        className="p-2 text-xs text-gray-700"
-                        title={m.user_id}
-                      >
-                        {m.display_name || '—'}
+                      <td className="p-2">
+                        {(myRole === 'owner' || myRole === 'admin') ? (
+                          <input
+                            className="w-full rounded border px-2 py-1 text-xs"
+                            value={m.display_name || ''}
+                            onChange={(e) => {
+                              const v = e.target.value;
+                              setTeam((prev) =>
+                                prev.map((x) =>
+                                  x.user_id === m.user_id
+                                    ? { ...x, display_name: v }
+                                    : x,
+                                ),
+                              );
+                            }}
+                            onBlur={async (e) => {
+                              const displayName = e.target.value.trim();
+                              try {
+                                const { data: session } =
+                                  await supabase.auth.getSession();
+                                const token = session.session?.access_token;
+                                const res = await fetch('/api/team/member', {
+                                  method: 'POST',
+                                  headers: {
+                                    'Content-Type': 'application/json',
+                                    ...(token
+                                      ? { Authorization: `Bearer ${token}` }
+                                      : {}),
+                                  },
+                                  body: JSON.stringify({
+                                    userId: m.user_id,
+                                    displayName,
+                                  }),
+                                });
+                                if (!res.ok)
+                                  throw new Error('Failed to save name');
+                              } catch (err) {
+                                toast({
+                                  title: 'Save failed',
+                                  description: String((err as any)?.message || err),
+                                  variant: 'error',
+                                });
+                              }
+                            }}
+                            placeholder="Display name"
+                          />
+                        ) : (
+                          <span className="text-xs text-gray-700">
+                            {m.display_name || '—'}
+                          </span>
+                        )}
+                      </td>
+                      <td className="p-2">
+                        {(myRole === 'owner' || myRole === 'admin') ? (
+                          <input
+                            className="w-full rounded border px-2 py-1 text-xs"
+                            value={m.phone || ''}
+                            onChange={(e) => {
+                              const v = e.target.value;
+                              setTeam((prev) =>
+                                prev.map((x) =>
+                                  x.user_id === m.user_id ? { ...x, phone: v } : x,
+                                ),
+                              );
+                            }}
+                            onBlur={async (e) => {
+                              try {
+                                const { data: session } =
+                                  await supabase.auth.getSession();
+                                const token = session.session?.access_token;
+                                const res = await fetch('/api/team/member', {
+                                  method: 'POST',
+                                  headers: {
+                                    'Content-Type': 'application/json',
+                                    ...(token
+                                      ? { Authorization: `Bearer ${token}` }
+                                      : {}),
+                                  },
+                                  body: JSON.stringify({
+                                    userId: m.user_id,
+                                    phone: e.target.value.trim(),
+                                  }),
+                                });
+                                if (!res.ok)
+                                  throw new Error('Failed to save phone');
+                              } catch (err) {
+                                toast({
+                                  title: 'Save failed',
+                                  description: String((err as any)?.message || err),
+                                  variant: 'error',
+                                });
+                              }
+                            }}
+                            placeholder="Phone"
+                          />
+                        ) : (
+                          <span className="text-xs text-gray-700">
+                            {m.phone || '—'}
+                          </span>
+                        )}
                       </td>
                       <td
                         className="p-2 text-xs text-gray-500"

--- a/drizzle/0002_profiles_rls_extend.sql
+++ b/drizzle/0002_profiles_rls_extend.sql
@@ -1,0 +1,31 @@
+-- Extend profiles RLS: allow tenant users to SELECT team directory, and admins to UPDATE member details.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'profiles' and policyname = 'tenant_can_select_profiles'
+  ) then
+    execute 'create policy tenant_can_select_profiles on public.profiles for select using (
+      tenant_id = (select tenant_id from public.profiles where user_id = auth.uid())
+    )';
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname = 'public' and tablename = 'profiles' and policyname = 'admin_can_update_profiles'
+  ) then
+    execute 'create policy admin_can_update_profiles on public.profiles for update using (
+      exists (
+        select 1 from public.profiles me
+        where me.user_id = auth.uid()
+          and me.tenant_id = profiles.tenant_id
+          and me.role in (''owner'',''admin'')
+      )
+    ) with check (
+      exists (
+        select 1 from public.profiles me
+        where me.user_id = auth.uid()
+          and me.tenant_id = profiles.tenant_id
+          and me.role in (''owner'',''admin'')
+      )
+    )';
+  end if;
+end $$;
+

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "demo:seed:min": "tsx scripts/seed.ts",
     "unseed": "tsx scripts/unseed.ts",
     "tenant:delete": "tsx scripts/unseed.ts",
-    "backfill:branches": "tsx scripts/backfill_branches.ts"
+    "backfill:branches": "tsx scripts/backfill_branches.ts",
+    "backfill:leads": "tsx scripts/backfill_leads_for_jobs.ts"
   },
   "dependencies": {
     "@sparticuz/chromium": "^127.0.0",

--- a/scripts/backfill_leads_for_jobs.ts
+++ b/scripts/backfill_leads_for_jobs.ts
@@ -1,0 +1,93 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  if (!url || !key) throw new Error('Missing Supabase env vars');
+  const sb = createClient(url, key, { auth: { persistSession: false } });
+
+  console.log('> Scanning jobs in Lead stage without linked lead...');
+  const { data: jobs, error: jErr } = await sb
+    .from('jobs')
+    .select('id, tenant_id, customer_id, branch_id, date_lead, created_at, lead_id')
+    .eq('status', 'Lead')
+    .is('lead_id', null)
+    .limit(1000);
+  if (jErr) throw jErr;
+  const rows = (jobs || []) as any[];
+  console.log(`  Found ${rows.length} job(s) to backfill`);
+
+  let created = 0;
+  let linked = 0;
+  for (const j of rows) {
+    try {
+      // Fetch customer details
+      const { data: cust, error: cErr } = await sb
+        .from('customers')
+        .select('name, phone, address')
+        .eq('id', j.customer_id)
+        .maybeSingle();
+      if (cErr) throw cErr;
+
+      // Try reuse existing lead by phone within tenant
+      let leadId: string | null = null;
+      if (cust?.phone) {
+        const { data: existing } = await sb
+          .from('leads')
+          .select('id, status')
+          .eq('tenant_id', j.tenant_id)
+          .eq('phone', cust.phone)
+          .order('date', { ascending: false })
+          .limit(1);
+        const reuse = Array.isArray(existing) ? existing[0] : null;
+        if (reuse?.id) {
+          leadId = reuse.id as string;
+          if (reuse.status !== 'Converted') {
+            await sb.from('leads').update({ status: 'Converted' }).eq('id', leadId);
+          }
+        }
+      }
+
+      if (!leadId) {
+        const date = (j as any).date_lead || (j as any).created_at?.slice(0, 10) || new Date().toISOString().slice(0, 10);
+        const { data: lead, error: lErr } = await sb
+          .from('leads')
+          .insert({
+            tenant_id: j.tenant_id,
+            date,
+            name: (cust as any)?.name || 'Lead',
+            phone: (cust as any)?.phone || null,
+            address: (cust as any)?.address || null,
+            interested_capacity_kw: null,
+            status: 'Converted',
+            branch_id: j.branch_id || null,
+            source: 'Job',
+          })
+          .select('id')
+          .single();
+        if (lErr) throw lErr;
+        leadId = (lead as any).id;
+        created++;
+      }
+
+      const { error: uErr } = await sb
+        .from('jobs')
+        .update({ lead_id: leadId })
+        .eq('id', j.id);
+      if (uErr) throw uErr;
+      linked++;
+      console.log(`  Linked job ${j.id} -> lead ${leadId}`);
+    } catch (e: any) {
+      console.error('  Failed for job', j.id, e?.message || e);
+    }
+  }
+
+  console.log(`Done. Created leads: ${created}, linked jobs: ${linked}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+

--- a/scripts/seed.full.ts
+++ b/scripts/seed.full.ts
@@ -12,21 +12,39 @@ async function main() {
   if (!key) throw new Error('Missing env SUPABASE_SERVICE_ROLE_KEY');
   const supabase = createClient(url, key);
 
-  const TENANT_ID: Id =
-    process.env.SEED_TENANT_ID ||
-    (await (async () => {
-      const { data, error } = await supabase
+  // Resolve tenant: if SEED_TENANT_ID is provided but missing, create it.
+  const TENANT_ID: Id = await (async () => {
+    const envId = process.env.SEED_TENANT_ID?.trim();
+    if (envId) {
+      const { data: existing } = await supabase
         .from('tenants')
-        .insert({ name: 'Demo Tenant' })
         .select('id')
-        .single();
-      if (error || !data?.id) {
-        throw new Error(
-          `Failed to create tenant: ${error?.message || 'unknown error'}. Have you applied migrations?`,
-        );
+        .eq('id', envId)
+        .maybeSingle();
+      if (!existing?.id) {
+        const { error } = await supabase
+          .from('tenants')
+          .insert({ id: envId, name: 'Demo Tenant' });
+        if (error) {
+          throw new Error(
+            `Failed to ensure tenant ${envId}: ${error.message}. Have you applied migrations?`,
+          );
+        }
       }
-      return data.id as string;
-    })());
+      return envId as string;
+    }
+    const { data, error } = await supabase
+      .from('tenants')
+      .insert({ name: 'Demo Tenant' })
+      .select('id')
+      .single();
+    if (error || !data?.id) {
+      throw new Error(
+        `Failed to create tenant: ${error?.message || 'unknown error'}. Have you applied migrations?`,
+      );
+    }
+    return data.id as string;
+  })();
 
   // Settings with company profile
   let res = await supabase.from('settings').upsert({

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -10,20 +10,37 @@ async function main() {
   if (!key) throw new Error('Missing env SUPABASE_SERVICE_ROLE_KEY');
   const supabase = createClient(url, key);
 
-  const TENANT_ID =
-    process.env.SEED_TENANT_ID ||
-    (await (async () => {
-      const { data, error } = await supabase
+  // Resolve tenant: if SEED_TENANT_ID provided but missing, create it.
+  const TENANT_ID = await (async () => {
+    const envId = process.env.SEED_TENANT_ID?.trim();
+    if (envId) {
+      const { data: existing } = await supabase
         .from('tenants')
-        .insert({ name: 'Demo Tenant' })
         .select('id')
-        .single();
-      if (error || !data?.id)
-        throw new Error(
-          `Failed to create tenant: ${error?.message || 'unknown error'}`,
-        );
-      return data.id as string;
-    })());
+        .eq('id', envId)
+        .maybeSingle();
+      if (!existing?.id) {
+        const { error } = await supabase
+          .from('tenants')
+          .insert({ id: envId, name: 'Demo Tenant' });
+        if (error)
+          throw new Error(
+            `Failed to ensure tenant ${envId}: ${error.message}`,
+          );
+      }
+      return envId as string;
+    }
+    const { data, error } = await supabase
+      .from('tenants')
+      .insert({ name: 'Demo Tenant' })
+      .select('id')
+      .single();
+    if (error || !data?.id)
+      throw new Error(
+        `Failed to create tenant: ${error?.message || 'unknown error'}`,
+      );
+    return data.id as string;
+  })();
 
   let res = await supabase.from('settings').upsert({
     tenant_id: TENANT_ID,

--- a/src/lib/supabaseMock.ts
+++ b/src/lib/supabaseMock.ts
@@ -184,20 +184,50 @@ class MockQuery {
   private _order: { key: string; ascending: boolean } | null = null;
   private _select: string | null = null;
   private _limit: number | null = null;
+  private _wantCount: boolean = false;
   constructor(table: TableName) {
     this.table = table;
   }
 
-  select(sel: string) {
+  select(sel: string, opts?: { count?: 'exact' | 'planned' | 'estimated'; head?: boolean }) {
     this._select = sel;
+    this._wantCount = !!opts?.count;
     return this;
   }
   eq(k: string, v: any) {
     this.filters.push([k, v]);
     return this;
   }
+  neq(k: string, v: any) {
+    this.filters.push([`__neq__${k}`, v]);
+    return this;
+  }
   in(k: string, vs: any[]) {
     /* simple contains */ this.filters.push([`__in__${k}`, vs]);
+    return this;
+  }
+  lt(k: string, v: any) {
+    this.filters.push([`__lt__${k}`, v]);
+    return this;
+  }
+  lte(k: string, v: any) {
+    this.filters.push([`__lte__${k}`, v]);
+    return this;
+  }
+  gt(k: string, v: any) {
+    this.filters.push([`__gt__${k}`, v]);
+    return this;
+  }
+  gte(k: string, v: any) {
+    this.filters.push([`__gte__${k}`, v]);
+    return this;
+  }
+  is(k: string, v: any) {
+    this.filters.push([`__is__${k}`, v]);
+    return this;
+  }
+  match(obj: Record<string, any>) {
+    Object.entries(obj || {}).forEach(([k, v]) => this.eq(k, v));
     return this;
   }
   order(key: string, { ascending = true } = {}) {
@@ -210,20 +240,56 @@ class MockQuery {
   }
 
   private applyFilters(rows: Row[]) {
-    return rows
-      .filter((r) =>
-        matchEq(
-          r,
-          this.filters.filter(([k]) => !k.startsWith('__in__')) as any[],
-        ),
-      )
-      .filter((r) =>
-        this.filters.every(([k, v]) =>
-          k.startsWith('__in__')
-            ? (v as any[]).includes(r[k.replace('__in__', '')])
-            : true,
-        ),
-      );
+    const cmp = (a: any, b: any) => {
+      // Strings (including ISO dates) compare lexicographically which is fine here
+      if (a == null && b == null) return 0;
+      if (a == null) return -1;
+      if (b == null) return 1;
+      if (typeof a === 'number' && typeof b === 'number') return a - b;
+      try {
+        const as = String(a);
+        const bs = String(b);
+        if (as === bs) return 0;
+        return as > bs ? 1 : -1;
+      } catch {
+        return 0;
+      }
+    };
+    return rows.filter((r) =>
+      this.filters.every(([k, v]) => {
+        if (!k.startsWith('__')) return r[k] === v;
+        if (k.startsWith('__in__')) {
+          const key = k.replace('__in__', '');
+          return (v as any[]).includes(r[key]);
+        }
+        if (k.startsWith('__neq__')) {
+          const key = k.replace('__neq__', '');
+          return r[key] !== v;
+        }
+        if (k.startsWith('__lt__')) {
+          const key = k.replace('__lt__', '');
+          return cmp(r[key], v) < 0;
+        }
+        if (k.startsWith('__lte__')) {
+          const key = k.replace('__lte__', '');
+          return cmp(r[key], v) <= 0;
+        }
+        if (k.startsWith('__gt__')) {
+          const key = k.replace('__gt__', '');
+          return cmp(r[key], v) > 0;
+        }
+        if (k.startsWith('__gte__')) {
+          const key = k.replace('__gte__', '');
+          return cmp(r[key], v) >= 0;
+        }
+        if (k.startsWith('__is__')) {
+          const key = k.replace('__is__', '');
+          if (v === null) return r[key] == null; // null or undefined treated as null
+          return r[key] === v;
+        }
+        return true;
+      }),
+    );
   }
 
   async single() {
@@ -242,7 +308,9 @@ class MockQuery {
       const me =
         db.profiles.find((p) => p.user_id === db.currentUserId) || null;
       // Return as array so .single/.maybeSingle work consistently
-      return { data: me ? [me] : [], error: null } as any;
+      const payload = { data: me ? [me] : [], error: null } as any;
+      if (this._wantCount) (payload as any).count = payload.data.length;
+      return payload;
     }
     rows = this.applyFilters(rows);
     if (this._order) {
@@ -322,7 +390,9 @@ class MockQuery {
       });
     }
     if (this._limit != null) rows = rows.slice(0, this._limit);
-    return { data: rows, error: null };
+    const payload: any = { data: rows, error: null };
+    if (this._wantCount) payload.count = rows.length;
+    return payload;
   }
 
   async then(resolve: (v: any) => void, reject?: (e: any) => void) {


### PR DESCRIPTION
…ant view + admin update

- Add policy to allow tenant SELECT of profiles and admin UPDATE
- API: POST /api/team/member to update display_name/phone
- Settings: inline edit for team directory

feat(leads): simplify UX, default Open filter, merge job-only cards

- Add filter bar (Open/All/Converted + Due Today)
- Show job-only Lead-stage cards as read-only with Link Lead action
- Clarify Jobs vs Leads counts via tile

feat(jobs): on create, ensure/reuse linked lead to avoid mismatch

fix(mock): implement is/neq/lt/lte/gt/gte/match + select count

chore: backfill script to create leads for jobs missing lead_id